### PR TITLE
Corrigindo o Order ID no endpoint de Notificações

### DIFF
--- a/classes/class-wc-pagseguro-gateway.php
+++ b/classes/class-wc-pagseguro-gateway.php
@@ -243,7 +243,7 @@ class WC_PagSeguro_Gateway extends WC_Payment_Gateway
         $api = new WC_PagSeguro_Api($this->settings);
         $transaction = $api->notification();
 
-        $order_id = str_replace('WC-', '', $transaction->getReference());
+        $order_id = explode('-', $transaction->getReference())[2];
 
         $order = new WC_Order($order_id);
 


### PR DESCRIPTION
O Order ID estava sendo buscado incorretamente no endpoint de Notificações de Transação, o que fazia com que os pedidos não fossem atualizados